### PR TITLE
Set L2 bridge default owner is deployer

### DIFF
--- a/deployment/1_createGenesis.js
+++ b/deployment/1_createGenesis.js
@@ -193,7 +193,7 @@ async function main() {
             [
                 networkIDL2,
                 globalExitRootL2Address,
-                zkevmAddressL2,
+                initialZkEVMDeployerOwner,
                 gasTokenAddress,
                 gasTokenNetwork,
                 WETHToken.address,


### PR DESCRIPTION
# Main Changes:

Set the default owner of the L2 bridge to the deployer address, same as L2 others contract. In the feature should transfer ownership to a multisig wallet.